### PR TITLE
example/documentation updates for legibility and consistency between related functions

### DIFF
--- a/R/rvn_gen_obsweights.R
+++ b/R/rvn_gen_obsweights.R
@@ -16,11 +16,11 @@
 #'
 #' @details
 #' for criterion ='BEFORE', all timestamps prior to the enddate have a
-#' weight of 1, 0 otherwise
+#' weight of 1, 0 otherwise \cr
 #' for criterion ='AFTER', all timestamps after the startdate have a
-#' weight of 1, 0 otherwise
+#' weight of 1, 0 otherwise \cr
 #' for criterion ='BETWEEN', all timestamps after the startdate and before
-#' the enddate have a weight of 1, 0 otherwise
+#' the enddate have a weight of 1, 0 otherwise \cr
 #' for criterion ='BETWEEN_CYCLIC', all julian days after the startdate and before
 #' the enddate have a weight of 1, 0 otherwise; if startdate is more than enddate,
 #' then the opposite is true, e.g, for startdate="2002-11-01" and enddate "2002-01-31",
@@ -57,6 +57,9 @@
 #'
 #'  # write observation weights to rvt file
 #'  rvn_rvt_obsweights("run1_Hydrographs_wts.rvt", wts2, 36, typestr="HYDROGRAPH")
+#'
+#'  # cleanup example files
+#'  unlink(x=c("run1_Hydrographs.rvt","run1_Hydrographs_wts.rvt"))
 #'
 #' @keywords Raven observations weights generate
 #'

--- a/R/rvn_rvh_read.R
+++ b/R/rvn_rvh_read.R
@@ -1,5 +1,6 @@
 #' @title Read Raven .rvh (watershed discretization) file
 #'
+#' @description
 #' This routine reads in a valid Raven watershed discretization (.rvh) file and returns the
 #' information about HRUs and Subbasins as data tables. It also returns a subbasin igraph
 #' network object which describes stream network connectivity and adds additional HRU-derived

--- a/R/rvn_rvt_flow.R
+++ b/R/rvn_rvt_flow.R
@@ -41,7 +41,6 @@
 #' \href{http://www.civil.uwaterloo.ca/jrcraig/Raven/Main.html}{Raven page}
 #' @keywords Raven rvt flow file
 #' @examples
-#'
 #' # load sample hydrograph data, two years worth of sim/obs
 #' data(rvn_hydrograph_data)
 #' obs <- rvn_hydrograph_data$hyd$Sub36_obs

--- a/R/rvn_rvt_obsfile.R
+++ b/R/rvn_rvt_obsfile.R
@@ -25,9 +25,12 @@
 #' flows <- rvn_ts_infill(mydata$hyd$Sub36_obs)
 #' rvn_rvt_obsfile("run1_Hydrographs.rvt", flows, 36, typestr = "HYDROGRAPH")
 #'
+#' # cleanup example files
+#' unlink('run1_Hydrographs.rvt')
+#'
 #' @keywords Raven observations
 #'
-#' @seealso \code{\link{rvn_ts_infill}} for infilling time series, and  \code{\link{rvn_rvt_obsweights}} to write an rvt observation weights file
+#' @seealso \code{\link{rvn_ts_infill}} for infilling time series, and  \code{\link{rvn_rvt_obsweights}} to write an rvt observation weights file.
 #' See also the \href{http://raven.uwaterloo.ca/}{Raven website}
 #' @export rvn_rvt_obsfile
 #' @importFrom zoo index

--- a/R/rvn_rvt_obsweights.R
+++ b/R/rvn_rvt_obsweights.R
@@ -37,6 +37,9 @@
 #'    startdate="2003-03-01")
 #'  wts2 <- wts2*wts # product merges weights
 #'
+#'  # show weights over time
+#'  plot(wts2)
+#'
 #'  # write observation weights to rvt file
 #'  rvn_rvt_obsweights("run1_Hydrographs_wts.rvt", wts2,
 #'    36, typestr="HYDROGRAPH")

--- a/R/rvn_ts_infill.R
+++ b/R/rvn_ts_infill.R
@@ -12,7 +12,7 @@
 #'
 #' @param ts valid xts time series
 #'
-#' @return {ts}{continuous xts time series}
+#' @return {ts}{ continuous xts time series}
 #'
 #' @author James R. Craig, University of Waterloo
 #'


### PR DESCRIPTION
Summary of changes to examples and documentation:

- added 'unlink' call to end of examples for `rvn_rvt_obsfile.R` and `rvn_gen_obsweights.R` to remove example output files from user directory (consistency with rvn_rvt_obsweights.R)
- added missing '@description' to `rvn_rvh_read.R`
- added extra line to plot parsed data weighting time series object for visualization in `rvn_rvt_obsweights.R` (consistency with rvn_gen_obsweights.R)
-general additions of spaces, periods, and line breaks to improve legibility in the rendered documentation.