### PR TITLE
Monthly bias plot fix

### DIFF
--- a/R/rvn_monthly_vbias.R
+++ b/R/rvn_monthly_vbias.R
@@ -52,13 +52,14 @@
 #' @export rvn_monthly_vbias
 #' @importFrom ggplot2 ggplot geom_bar aes scale_y_continuous scale_x_continuous geom_hline geom_text
 #' @importFrom xts apply.monthly
-rvn_monthly_vbias <- function (sim, obs, add_line = TRUE, normalize = TRUE, add_labels = TRUE)
+rvn_monthly_vbias <- function (sim, obs, add_line = TRUE, normalize = TRUE, add_labels = TRUE,
+                               incomplete_month = FALSE)
 {
 
   nmon <- NULL
 
-  obs.monthly <- apply.monthly(obs, sum, na.rm = TRUE)
-  sim.monthly <- apply.monthly(sim, sum, na.rm = TRUE)
+  obs.monthly <- apply.monthly(obs, sum, na.rm = incomplete_month)
+  sim.monthly <- apply.monthly(sim, sum, na.rm = imcomplete_month)
   mvbias <- matrix(NA, nrow = 12, ncol = 1)
   colnames(mvbias) <- c("mvbias")
   rownames(mvbias) <- rvn_month_names(TRUE)
@@ -112,5 +113,9 @@ rvn_monthly_vbias <- function (sim, obs, add_line = TRUE, normalize = TRUE, add_
                   hjust = 0.5)
     }
   }
+  
+  print(sprintf('Number of months excluded: %i', sum(is.na(diff))))
+  print(sprintf('Number of months included: %i', sum(!is.na(diff))))
+  
   return(list(df.mvbias = mvbias,plot=p1))
 }


### PR DESCRIPTION
In the equation below, observed runoff is summed monthly even when there are days within a specific month with many NAN values. Besides, if all values within a month are NAN, then the result is 0 which results in "diff" with Inf values when using the flag normalize =TRUE due to the division by 0 and therefore no plot.
obs.monthly <- apply.monthly(obs, sum, na.rm = TRUE)

The simulated runoff is also summed monthly, but there is no gaps in the daily data thus subtracting monthly simulated runoff from monthly observed runoff will always tend to be overestimated if months missing some days of observed data are included in the analysis. My suggestion is to include a flag to exclude the summation of observed months with incomplete data and printing a couple of lines to quickly check how many were included/excluded fromthe analysis.